### PR TITLE
feat: make page work even after refresh by storing token in localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13589,6 +13589,11 @@
         "vue-demi": "*"
       }
     },
+    "pinia-plugin-persistedstate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-1.2.0.tgz",
+      "integrity": "sha512-5Xp5Vc2qZXpPgYlq7kLdQU0FEMiTUyFNYAqC5h9KzVIxWI5QucSasmTg8mSZRXlTe5jsXSl/xWLVx0+jBVeDww=="
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.21.4",
     "core-js": "^3.6.5",
     "pinia": "^2.0.0-rc.8",
+    "pinia-plugin-persistedstate": "^1.2.0",
     "primeicons": "^4.1.0",
     "primevue": "^3.7.2",
     "vue": "^3.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
 import PrimeVue from "primevue/config";
+import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
 
 import "primevue/resources/themes/saga-blue/theme.css";
 import "primevue/resources/primevue.min.css";
@@ -9,8 +10,11 @@ import "primeicons/primeicons.css";
 import Tooltip from "primevue/tooltip";
 import { createPinia } from "pinia";
 
+const pinia = createPinia();
+pinia.use(piniaPluginPersistedstate);
+
 createApp(App)
-  .use(createPinia())
+  .use(pinia)
   .use(router)
   .use(PrimeVue)
   .directive("tooltip", Tooltip)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
 import Home from "../views/Home.vue";
 import Editor from "@/views/Editor.vue";
+import Callback from "@/views/Callback.vue";
+import { useMultiFeedStore } from "@/store/MultifeedStore";
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -9,7 +11,12 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: "/authorize_callback",
+    component: Callback,
+  },
+  {
+    path: "/editor",
     component: Editor,
+    meta: { requiresAccessToken: true },
   },
 ];
 
@@ -18,4 +25,12 @@ const router = createRouter({
   routes,
 });
 
+router.beforeEach((to, from, next) => {
+  const multiFeedStore = useMultiFeedStore();
+  if (to.meta.requiresAccessToken && multiFeedStore.accessToken === "") {
+    next({ path: "/" });
+  } else {
+    next();
+  }
+});
 export default router;

--- a/src/store/MultifeedStore.ts
+++ b/src/store/MultifeedStore.ts
@@ -14,6 +14,7 @@ import { RedditApi } from "@/api/RedditApi";
 
 export const useMultiFeedStore = defineStore("multi-feed", {
   state: () => ({
+    accessToken: "" as string,
     nameOfMultis: [] as string[],
     dataTableContent: [] as DatatableRow[],
     subredditChanges: new Map<string, Action>(),
@@ -23,17 +24,22 @@ export const useMultiFeedStore = defineStore("multi-feed", {
     multisService: {} as MultisService,
     filters: {} as DataTableFilter,
   }),
+  persist: {
+    paths: ["accessToken"],
+  },
   actions: {
     async extractAccessToken(href: string) {
-      const accessToken = await new AccessTokenFactory().extractAccessToken(
+      this.accessToken = await new AccessTokenFactory().extractAccessToken(
         axios.create({ baseURL: process.env.VUE_APP_REDDIT_URL }),
         href
       );
+    },
+    async initService() {
       const axiosInstance = axios.create({
         baseURL: process.env.VUE_APP_OAUTH_REDDIT_URL,
         timeout: 5000,
         headers: {
-          Authorization: "bearer " + accessToken,
+          Authorization: "bearer " + this.accessToken,
         },
       });
       this.multisService = new MultisService(new RedditApi(axiosInstance));

--- a/src/views/Callback.vue
+++ b/src/views/Callback.vue
@@ -1,0 +1,20 @@
+<template>
+  <h1>
+    REDIRECTING...
+    <ProgressSpinner style="width: 30px; height: 30px" strokeWidth="8" />
+  </h1>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "@vue/runtime-core";
+import { useMultiFeedStore } from "@/store/MultifeedStore";
+import ProgressSpinner from "primevue/progressspinner";
+import router from "@/router";
+
+const multiFeedStore = useMultiFeedStore();
+
+onMounted(async () => {
+  await multiFeedStore.extractAccessToken(window.location.href);
+  await router.push("/editor");
+});
+</script>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -46,7 +46,6 @@
         <template #body="{ data }">
           <Checkbox
             :class="data.name + '_subscribed'"
-            id="binary"
             v-model="data.subscribed"
             :binary="true"
             @update:modelValue="onChangeSubscriptionStatus($event, data)"
@@ -69,7 +68,6 @@
       >
         <template #body="slotProps">
           <Checkbox
-            id="binary"
             v-model="slotProps.data[multi]"
             :class="slotProps.data.name + '_' + multi"
             :binary="true"
@@ -112,7 +110,7 @@ const multiSortMeta = ref<{ field: string; order: number }[]>([
 onMounted(async () => {
   isLoading.value = true;
 
-  await multiFeedStore.extractAccessToken(window.location.href);
+  await multiFeedStore.initService();
   await multiFeedStore.readMultiFeedInformationFromReddit();
 
   dataTableContent.value = multiFeedStore.dataTableContent;

--- a/tests/unit/service/MultisService.spec.ts
+++ b/tests/unit/service/MultisService.spec.ts
@@ -44,7 +44,7 @@ describe("MultisService.ts", () => {
     it("should delegate to redditApi", async function () {
       const onfulfilled: Promise<MultiReddit[]> =
         Promise.resolve(multiRedditArray);
-      expect(redditApi.getMultiMine.returns(onfulfilled));
+      redditApi.getMultiMine.returns(onfulfilled);
 
       const actual = await multisService.getMultiMine();
 


### PR DESCRIPTION
Additionally, removed unused but duplicated id from Editor.vue and added
router guard to require store item accessToken to be not empty for
entering Editor page.